### PR TITLE
fix: first-login → account-setup + guard defers role routing

### DIFF
--- a/mybeachtrivia.com/beachTriviaPages/js/auth-route-guard.v2.js
+++ b/mybeachtrivia.com/beachTriviaPages/js/auth-route-guard.v2.js
@@ -86,9 +86,17 @@
         }
 
         if (onLogin) {
-          if (!setupCompleted) return redirectOnce(PATHS.setup);
-          return redirectOnce(defaultDest(roles));
-        }
+  // If profile not complete → onboarding
+  if (!setupCompleted) return redirectOnce(PATHS.setup);
+  // If a 'next' is provided, honor it
+  try {
+    var params = new URLSearchParams(location.search);
+    var next = params.get('next');
+    if (next) return redirectOnce(next);
+  } catch (_) {}
+  // Otherwise, let login.js handle role selection (no auto-redirect here)
+  return;
+}
 
         if (onSetup) {
           if (setupCompleted) return redirectOnce(defaultDest(roles));


### PR DESCRIPTION
Restores first-login redirect to /onboarding/account-setup/; on login page the route-guard now only sends to setup or honors ?next, otherwise defers to login.js.